### PR TITLE
allow-parameters-to-be-an-array

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambda_open_api (0.1.3)
+    lambda_open_api (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/lambda_open_api/body_parameter.rb
+++ b/lib/lambda_open_api/body_parameter.rb
@@ -4,14 +4,8 @@ module LambdaOpenApi
   class BodyParameter
     attr_accessor :data
 
-    def initialize(data = nil, file_name: nil)
-      @file_name = file_name
-
+    def initialize(data = nil)
       @data = data
-      if data.nil? && File.exists?("lib/lambda_open_api/examples/requests/#{file_name}.json")
-        json = File.open("lib/lambda_open_api/examples/requests/#{file_name}.json").read
-        @data = JSON.parse(json)
-      end
     end
 
     def json

--- a/lib/lambda_open_api/body_property.rb
+++ b/lib/lambda_open_api/body_property.rb
@@ -15,6 +15,22 @@ module LambdaOpenApi
             "type"=>  "object",
             "properties"=> hash.props
           }
+        elsif value.is_a?(Array)
+          item_props = {}
+
+          value.each do |item|
+            hash = LambdaOpenApi::BodyProperty.new
+            hash.generate(item)
+            item_props.merge!(hash.props)
+          end
+
+          props[key.to_s] = {
+            "type"=>  "array",
+            "items"=> {
+              "type" => "object",
+              "properties" => item_props
+            }
+          }
         else
           props[key.to_s] = {
             "type"=>  value_type(value)

--- a/lib/lambda_open_api/version.rb
+++ b/lib/lambda_open_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaOpenApi
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/spec/lambda_open_api/example.json
+++ b/spec/lambda_open_api/example.json
@@ -46,7 +46,7 @@
               "description": "",
               "type": "object",
               "properties": {
-                "values": {
+                "key": {
                   "type": "string"
                 }
               },
@@ -62,17 +62,17 @@
               "application/json": {
                 "name": "Timbo Baggins",
                 "email": "tbaggings@onering.com",
-                "key": null
+                "key": "some_key_value"
               }
             }
           }
         }
       }
     },
-    "users": {
+    "includes/objects/and/arrays": {
       "post": {
         "tags": [
-          "Users"
+          "Use cases"
         ],
         "summary": null,
         "description": null,
@@ -94,6 +94,31 @@
               "properties": {
                 "key": {
                   "type": "string"
+                },
+                "object": {
+                  "type": "object",
+                  "properties": {
+                    "key_1": {
+                      "type": "string"
+                    },
+                    "key_2": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "array": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "item_1": {
+                        "type": "string"
+                      },
+                      "item_2": {
+                        "type": "string"
+                      }
+                    }
+                  }
                 }
               },
               "required": [

--- a/spec/lambda_open_api/my_lambda_basic_spec.rb
+++ b/spec/lambda_open_api/my_lambda_basic_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MyLambda do
         parameter({id: 1})
 
         event_body({
-          values: ""
+          key: "some_key_value"
         }.to_json)
 
         event_headers({
@@ -31,25 +31,11 @@ RSpec.describe MyLambda do
         })
 
         run_example do
-          expect(lambda_response[:body]).to eq({:email=>"tbaggings@onering.com", :name=>"Timbo Baggins", key: nil})
+          expect(lambda_response[:body]).to eq({:email=>"tbaggings@onering.com", :name=>"Timbo Baggins", key: "some_key_value"})
           expect(lambda_response[:statusCode]).to eq(200)
         end
       end
     end
 
-    post "users" do
-      example_case "200" do
-        event_body({
-          key: "abcd"
-        }.to_json)
-
-        event_headers({
-          "Api-Key" => "the_api_key"
-        })
-        run_example do
-          expect(lambda_response[:body]).to eq({:email=>"tbaggings@onering.com", :name=>"Timbo Baggins", key: "abcd"})
-        end
-      end
-    end
   end
 end

--- a/spec/lambda_open_api/my_lambda_spec.rb
+++ b/spec/lambda_open_api/my_lambda_spec.rb
@@ -13,35 +13,16 @@ end
 
 RSpec.describe MyLambda do
 
-  resource "Users" do
+  resource "Use Cases" do
 
-    get "users/{id}" do
-      path_summery "Some very high level details"
-      path_description "Some more details about this path"
-
+    post "includes/objects/and/arrays" do
       example_case "200" do
-        parameter({id: 1})
-
-        event_body({
-          values: ""
-        }.to_json)
-
-        event_headers({
-          "Api-Key" => "the_api_key"
-        })
-
-        run_example do
-          expect(lambda_response[:body]).to eq({:email=>"tbaggings@onering.com", :name=>"Timbo Baggins", key: nil})
-          expect(lambda_response[:statusCode]).to eq(200)
-        end
-      end
-    end
-
-    post "users" do
-      example_case "200" do
-        event_body({
-          key: "abcd"
-        }.to_json)
+        event_body(
+          {
+            key: "abcd",
+            object: {key_1: "value_1", key_2: "value_2"},
+            array: [{item_1: "value_1", item_2: "value_2"}]
+          }.to_json)
 
         event_headers({
           "Api-Key" => "the_api_key"


### PR DESCRIPTION
Why
It doesn't properly format the parameters when the request body contains an array of objects

Solution
correctly format the parameters in the event that the body contains an array of objects do some clean up
make new test cases for this use case