### PR TITLE
add-file-sets-option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
-/open_api.json
+/open_api/
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambda_open_api (0.2.0)
+    lambda_open_api (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/lambda_open_api/builder.rb
+++ b/lib/lambda_open_api/builder.rb
@@ -66,8 +66,9 @@ module LambdaOpenApi
 
     def run_example(test_name=nil, &block)
       klass = create_class
+      test_name ||= "#{@action.http_verb} #{@action.path_name}"
 
-      it "#{test_name || @action.path_name}" do
+      it "#{test_name}" do
         @klass = klass
         def lambda_response
           @lambda_response ||= @klass.invoke

--- a/lib/lambda_open_api/configuration.rb
+++ b/lib/lambda_open_api/configuration.rb
@@ -1,9 +1,9 @@
 module LambdaOpenApi
   class Configuration
-    attr_accessor :file_name, :title, :description, :version, :host, :schemes, :consumes, :produces
+    attr_accessor :file_name, :title, :description, :version, :host, :schemes, :consumes, :produces, :file_sets
 
     def initialize
-      @file_name = "open_api.json"
+      @file_name = "open_api/open_api.json"
       @title = "Workflow Settings Api"
       @description = "About this api"
       @version = "1"
@@ -11,6 +11,7 @@ module LambdaOpenApi
       @schemes = ["https"]
       @consumes = ["application/json"]
       @produces = ["application/json"]
+      @file_sets = []
     end
   end
 end

--- a/lib/lambda_open_api/event.rb
+++ b/lib/lambda_open_api/event.rb
@@ -13,6 +13,10 @@ module LambdaOpenApi
                   :body,
                   :is_base64_encoded
 
+    def initialize
+      @body = "{}"
+    end
+
     def json
       {
         "resource" => resource,

--- a/lib/lambda_open_api/formatter.rb
+++ b/lib/lambda_open_api/formatter.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 
 module LambdaOpenApi
   class Formatter
@@ -10,12 +11,25 @@ module LambdaOpenApi
       end
 
       def generate_docs
-        open_api = high_level.merge({"paths" => @paths})
 
-        File.open(LambdaOpenApi.configuration.file_name, "w") {|f| f.write(JSON.pretty_generate(open_api) + "\n") }
+
+
+
+        if uses_file_sets?
+          LambdaOpenApi.configuration.file_sets.each do |file_set|
+            LambdaOpenApi.configuration.host = file_set[:host]
+
+            open_api = high_level_structure.merge({"paths" => @paths})
+
+            create_file(file_set[:file_name], open_api)
+          end
+        else
+          open_api = high_level_structure.merge({"paths" => @paths})
+          create_file(LambdaOpenApi.configuration.file_name, open_api)
+        end
       end
 
-      def high_level
+      def high_level_structure
         {
           "swagger" => "2.0",
           "info" => {
@@ -28,6 +42,23 @@ module LambdaOpenApi
           "consumes" => LambdaOpenApi.configuration.consumes,
           "produces" => LambdaOpenApi.configuration.produces
         }
+      end
+
+      def uses_file_sets?
+        LambdaOpenApi.configuration.file_sets&.is_a?(Array) &&
+        LambdaOpenApi.configuration.file_sets.any?
+      end
+
+      def create_file(file_name, file_content)
+        dirname = File.dirname(file_name)
+        p dirname
+        unless File.directory?(dirname)
+          p 'to create'
+          p FileUtils.mkdir_p(dirname)
+        end
+
+
+        File.open(file_name, "w") {|f| f.write(JSON.pretty_generate(file_content) + "\n") }
       end
     end
   end

--- a/lib/lambda_open_api/version.rb
+++ b/lib/lambda_open_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaOpenApi
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/output_tester.rb
+++ b/spec/output_tester.rb
@@ -6,11 +6,11 @@ Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => tru
 
 class FormatterTester < Minitest::Test
   def test_ask_returns_an_answer
-    File.delete("open_api.json") if File.exist?("open_api.json")
+    File.delete("open_api/open_api.json") if File.exist?("open_api/open_api.json")
 
     `rspec`
 
-    output_file = File.read("open_api.json")
+    output_file = File.read("open_api/open_api.json")
     expected_file = File.read("spec/lambda_open_api/example.json")
 
     assert output_file == expected_file


### PR DESCRIPTION
Why
To allow users to create an array of settings. A unique file will be created for each set