### PR TITLE
add-http-method-config-for-version-2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lambda_open_api (0.3.0)
+    lambda_open_api (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/lambda_open_api/builder.rb
+++ b/lib/lambda_open_api/builder.rb
@@ -50,7 +50,7 @@ module LambdaOpenApi
     def crud_verb(verb, path)
       @action = LambdaOpenApi::Action.new(name: @name, http_verb: verb, path_name: path)
       @event = @default_event.dup
-      @event.request_context = {"httpMethod" => verb.upcase}
+      @event.request_context = {"httpMethod" => verb.upcase, "http" => {"method" => verb.upcase}}
 
       yield
 

--- a/lib/lambda_open_api/configuration.rb
+++ b/lib/lambda_open_api/configuration.rb
@@ -7,7 +7,7 @@ module LambdaOpenApi
       @title = "Workflow Settings Api"
       @description = "About this api"
       @version = "1"
-      @host = "https://google.com"
+      @host = "google.com"
       @schemes = ["https"]
       @consumes = ["application/json"]
       @produces = ["application/json"]

--- a/lib/lambda_open_api/version.rb
+++ b/lib/lambda_open_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaOpenApi
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Why
The way it is setting the http method verb only works when the api gateway is using version 1.

Solution
Make an update so that it will work with both versions