### PR TITLE
handle-when-response-is-nil

### DIFF
--- a/lib/lambda_open_api/invoker.rb
+++ b/lib/lambda_open_api/invoker.rb
@@ -8,6 +8,7 @@ module LambdaOpenApi
     end
 
     def response_body
+      return unless response
       response["body"] || response[:body] || response
     end
 

--- a/lib/lambda_open_api/version.rb
+++ b/lib/lambda_open_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LambdaOpenApi
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Why
if the lambda response is nil. an error will be thrown

solution
return nil if it is nil